### PR TITLE
chore(deps): обновить Django до 6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{name = "Hexlet Team", email = "<info@hexlet.io>"}]
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "django>=6.0.6",
+    "django>=6.1",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -40,16 +40,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "6.0.6"
+version = "6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/29/ac41e16097af67066d97a7d5775c5d8e7efc5d0284f6b0a159e07b9adb92/django-6.0.6.tar.gz", hash = "sha256:ad03916ba59523d781ae5c3f631960c23d69a9d9c43cecda52fc23b47e953713", size = 10905525, upload-time = "2026-06-03T13:02:46.503Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/42/6cb20996733984c1f6661daeda3877990836c76c633c6c8879d39f7120eb/django-6.1.tar.gz", hash = "sha256:86a2aacd59b817e4d6ac2ebfe22356c58f66f7b24e503f71b7c2fead677ee48b", size = 11223034, upload-time = "2026-08-05T19:21:53.789Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/50/23f9dc45483419a3cc2085b498b25adfbf10642b2941c73e6d2dfaffc9ab/django-6.0.6-py3-none-any.whl", hash = "sha256:25148b1194c47c2e685e5f5e9c5d59c78b075dfd282cb9618861ba6c1708f4d2", size = 8373354, upload-time = "2026-06-03T13:02:41.72Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9c/ce847620134cfab903e75690c498af73b46abbede2912ea89bd76d5c1e76/django-6.1-py3-none-any.whl", hash = "sha256:6c132cd980c9392b06807d4ca52d72530d631dc65a85d9dacede00a780cefbbe", size = 8417399, upload-time = "2026-08-05T19:21:47.285Z" },
 ]
 
 [[package]]
@@ -290,7 +290,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "django", specifier = ">=6.0.6" }]
+requires-dist = [{ name = "django", specifier = ">=6.1" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Зачем

Django 6.1 вышла 2026-08-05. Dependabot в этом репозитории настроен на `interval: "monthly"`, последний прогон был 2026-08-01, за четыре дня до релиза, поэтому обновление пришло бы только 2026-09-01. Делается руками, потому что от версии зависят правки уроков курса `python_django_orm_course`.

## Почему поднята нижняя граница, а не только лок

Курс теперь учит `transaction.savepoint_create()` и `QuerySet.fetch_mode(models.FETCH_PEERS)` — в Django 6.0 их нет. Плюс `savepoint()` на 6.1 печатает `RemovedInDjango70Warning: savepoint() is deprecated`, то есть студент увидел бы предупреждение в REPL.

## Проверено на этой ветке

- `make setup`, `make test` → 1 passed
- `make lint` → All checks passed
- `manage.py check` → no issues
- `manage.py makemigrations --check --dry-run` → No changes detected (дрейфа нет, `DEFAULT_AUTO_FIELD` прописан явно)
- `shell_plus` стартует, импортирует модели и печатает SQL с `Execution time`
- `django-extensions 4.1` совместим

Отдельно прогнаны все примеры уроков, которые опираются на этот проект, с `warnings.simplefilter("error", DeprecationWarning)`: ни одного устаревшего вызова.

🤖 Generated with [Claude Code](https://claude.com/claude-code)